### PR TITLE
Add travil-ci support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: erlang
+otp_release:
+  - R15B02
+  - R15B01
+  - R15B
+  - R14B04
+  - R14B03
+  - R14B02

--- a/README.org
+++ b/README.org
@@ -80,3 +80,8 @@ the folks at BeeBole.
 - Christopher Brown
 - Christopher Maier
 - John Keiser
+
+** Build status
+
+#+ATTR_HTML: alt="Build status images" title="Build status on Travis-CI"
+[[https://travis-ci.org/seth/ej.png]]


### PR DESCRIPTION
This pull requests adds a travis-ci configuration file, and a build status image to the readme file.
For it to take effect you would need to enable the ej repo on https://travis-ci.org.

Thanks :)
