### PR TITLE
Ability to select items for which key starts with specified prefix

### DIFF
--- a/src/ej.erl
+++ b/src/ej.erl
@@ -934,6 +934,21 @@ ej_test_() ->
                                 ej:get({"users", {select, all}, "company"}, Data))
            end},
 
+          {"ej:get startswith ",
+           fun() ->
+                Data = {[
+                    {<<"admin:1:name">>, <<"Admin1">>},
+                    {<<"admin:2:name">>, <<"Admin2">>},
+                    {<<"user:1:name">>, <<"User1">>},
+                    {<<"user:2:name">>, <<"User2">>}]},
+                ?assertEqual(undefined, ej:get({{startswith, <<"guest">>}}, Data)),
+                ?assertMatch([], ej:get({{startswith, <<"guest">>}}, Data, [])),
+                ?assertMatch([
+                    {<<"user:1:name">>, <<"User1">>},
+                    {<<"user:2:name">>, <<"User2">>}],
+                    ej:get({{startswith, <<"user">>}}, Data))
+           end},
+
           {"ej:set, replacing existing value, keys is tuple",
            fun() ->
                    Path = {"widget", "window", "name"},


### PR DESCRIPTION
For example can select all users in following json-data:

``` json
{
    "user:1:name" : "User1",
    "user:2:name": "User2"
}
```

``` erlang
Users = ej:get({{startswith, <<"user">>}}, Data),
```
