### PR TITLE
Test for non-binary literal match

### DIFF
--- a/src/ej.erl
+++ b/src/ej.erl
@@ -689,20 +689,17 @@ check_value_spec(_Key, boolean, Val, _Ctx) when Val =:= true; Val =:= false ->
 check_value_spec(Key, boolean, Val, #spec_ctx{path = Path}) ->
     invalid_for_type(boolean, Val, Key, Path);
 
-check_value_spec(_Key, Val, Val, _Ctx) when is_binary(Val) ->
+check_value_spec(_Key, Val, Val, _Ctx) ->
     %% exact match desired
     ok;
-check_value_spec(Key, SpecVal, Val, #spec_ctx{path = Path}) when is_binary(SpecVal) ->
+check_value_spec(Key, SpecVal, Val, #spec_ctx{path = Path}) ->
     %% exact match failed
     #ej_invalid{type = exact,
                 key = make_key(Key, Path),
                 found = Val,
-                expected_type = string,
+                expected_type = json_type(SpecVal),
                 found_type = json_type(Val),
-                msg = SpecVal};
-check_value_spec(Key, SpecVal, Val, #spec_ctx{path = Path}) ->
-    %% catch all
-    error({unknown_spec, SpecVal, {key, make_key(Key, Path)}, {value, Val}, {path, Path}}).
+                msg = SpecVal}.
 
 
 invalid_for_type(ExpectType, Val, Key, Path) ->

--- a/test/ej_valid_test.erl
+++ b/test/ej_valid_test.erl
@@ -550,6 +550,112 @@ deep_struct_object_test_() ->
      ?_assertMatch(#ej_invalid{}, ej:valid(Spec, ObjNotOk))
     ].
 
+literal_match_test_() ->
+    [{Message, ?_assertEqual(ok, ej:valid(Spec, Object))} ||
+         {Message, Object, Spec} <- [
+                                     {"strings can match literally",
+                                      {[{<<"foo">>, <<"bar">>},
+                                        {<<"bar">>, <<"quuz">>}]},
+                                      {[{<<"foo">>, <<"bar">>},
+                                        {<<"bar">>, string}]}
+                                      },
+                                     {"integers can match literally",
+                                      {[{<<"foo">>, 1},
+                                        {<<"bar">>, 2}]},
+                                      {[{<<"foo">>, 1},
+                                        {<<"bar">>, number}]}
+                                     },
+                                     {"floats can match literally",
+                                      {[{<<"foo">>, 3.14},
+                                        {<<"bar">>, 2.17}]},
+                                      {[{<<"foo">>, 3.14},
+                                        {<<"bar">>, number}]}
+                                     },
+                                     {"arrays can match literally",
+                                      {[{<<"foo">>, [1,2,3]},
+                                        {<<"bar">>, [4,5,6]}]},
+                                      {[{<<"foo">>, [1,2,3]},
+                                        {<<"bar">>, {array_map, number}}]}
+                                     },
+                                     {"objects can match literally",
+                                      {[
+                                        {<<"foo">>, {[{<<"bar">>, <<"baz">>}]}},
+                                        {<<"bar">>, {[{<<"blah">>, <<"blahblah">>}]}}
+                                       ]},
+                                      {[
+                                        {<<"foo">>, {[{<<"bar">>, <<"baz">>}]}},
+                                        {<<"bar">>, {object_map, {{keys, string}, {values, string}}}}
+                                       ]}
+                                     },
+                                     {"booleans can match literally",
+                                      {[{<<"foo">>, true},
+                                        {<<"bar">>, false}]},
+                                      {[{<<"foo">>, true},
+                                        {<<"bar">>, boolean}]}
+                                     }
+                                    ]
+    ].
+
+literal_match_failures_test_() ->
+    [{Message, ?_assertMatch(#ej_invalid{}, ej:valid(Spec, Object))} ||
+         {Message, Object, Spec} <- [
+                                     {"strings can fail to match literally",
+                                      {[{<<"foo">>, <<"bar">>}]},
+                                      {[{<<"foo">>, <<"barf">>}]}
+                                     },
+                                     {"integers can fail to match literally",
+                                      {[{<<"foo">>, 1}]},
+                                      {[{<<"foo">>, 100}]}
+                                     },
+                                     {"floats can fail to match literally",
+                                      {[{<<"foo">>, 3.14}]},
+                                      {[{<<"foo">>, 3.141}]}
+                                     },
+                                     {"arrays can fail match literally",
+                                      {[{<<"foo">>, [1,2,3]}]},
+                                      {[{<<"foo">>, [1,2,3,4]}]}
+                                     },
+                                     {"arrays can fail in other ways to match literally",
+                                      {[{<<"foo">>, [1,2,3]}]},
+                                      {[{<<"foo">>, [1,2]}]}
+                                     },
+                                     {"arrays can fail in so many other ways to match literally",
+                                      {[{<<"foo">>, [1,2,3]}]},
+                                      {[{<<"foo">>, [1,4,3]}]}
+                                     },
+                                     {"objects can fail to match literally",
+                                      {[
+                                        {<<"foo">>, {[{<<"bar">>, <<"baz">>}]}}
+                                       ]},
+                                      {[
+                                        {<<"foo">>, {[{<<"bar">>, <<"bazbazbaz">>}]}}
+                                       ]}
+                                     },
+                                     {"objects can fail in other ways to match literally",
+                                      {[
+                                        {<<"foo">>, {[{<<"bar">>, <<"baz">>}]}},
+                                        {<<"bar">>, 123}
+                                       ]},
+                                      {[
+                                        {<<"foo">>, {[{<<"bar">>, <<"bazbaz">>}]}}
+                                       ]}
+                                     },
+                                     {"objects can fail in other ways to match literally",
+                                      {[
+                                        {<<"foo">>, {[{<<"bar">>, <<"baz">>}]}}
+                                       ]},
+                                      {[
+                                        {<<"foo">>, {[{<<"bar">>, <<"baz">>}]}},
+                                        {<<"bar">>, 123}
+                                       ]}
+                                     },
+                                     {"booleans can fail to match literally",
+                                      {[{<<"foo">>, true}]},
+                                      {[{<<"foo">>, false}]}
+                                     }
+                                    ]
+    ].
+
 basic(Name) ->
     {[{<<"name">>, Name}]}.
 
@@ -571,4 +677,3 @@ regex_for(_) ->
     Pat = <<"^[[:alpha:]]+$">>,
     {ok, Regex} = re:compile(Pat),
     {Regex, Pat}.
-


### PR DESCRIPTION
Previously, only binary values were permitted as literal match specs;
now any datatype can be matched literally.
