### PR TITLE
Fix spec for nested ej:valid validations

### DIFF
--- a/src/ej.erl
+++ b/src/ej.erl
@@ -400,7 +400,7 @@ delete(Keys, Obj) when is_list(Keys) ->
                             ej_array_map()       |
                             ej_object_map()      |
                             ej_any_of()          |
-                            {[ej_json_val_spec()]}.
+                            {[ej_json_spec_rule()]}.
 
 -spec valid(Spec :: ej_json_spec(), Obj:: json_object() | json_array()) -> ok | #ej_invalid{}.
 %% @doc Validate JSON terms. Validity is determined by the


### PR DESCRIPTION
I believe this last type was meant to capture the fact that ej:valid
supports nested specs like so:

    ej:valid({[
               {<<"name">>, string},
               {<<"modified_by">>, string},
               {<<"with">>, {[{<<"priority">>, number}]}}]}, JSON)

However, this call would be a violation of the spec as written.

Background:

Running dialyzer with Erlang 18.3 on chef-analytics (private github
repository) was yielding a `no local return` warning.  The cause
appeared to be a call to ej:valid that, when run in an erl shell, did in
fact return. Fixing this spec solves fixes the failure.

Signed-off-by: Steven Danna <steve@chef.io>